### PR TITLE
Fix #10: mainブランチをロック

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/settings.yml @dai-motoki

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,11 @@
+branch_protection_rules:
+  - branch_name_pattern: main
+    enforce_admins: true
+    required_status_checks:
+      strict: true
+      contexts:
+        - ci-test
+    required_pull_request_reviews:
+      dismiss_stale_reviews: true
+      require_code_owner_reviews: true
+      required_approving_review_count: 1

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,10 +1,6 @@
 branch_protection_rules:
   - branch_name_pattern: main
     enforce_admins: true
-    required_status_checks:
-      strict: true
-      contexts:
-        - ci-test
     required_pull_request_reviews:
       dismiss_stale_reviews: true
       require_code_owner_reviews: true


### PR DESCRIPTION
Fix #10: mainブランチをロック

## 変更内容
- `.github/CODEOWNERS`ファイルを追加し、`settings.yml`ファイルの変更に対してコードオーナーのレビューを必須とするように設定しました。
- `.github/settings.yml`ファイルを追加し、以下のブランチ保護ルールを設定しました。
  - mainブランチへのプッシュを制限
  - プルリクエストに対して、1人以上のレビュー承認を必須化
  - プルリクエストに対して、コードオーナーのレビューを必須化

## 目的
mainブランチに対する変更を制限し、レビュープロセスを強化することで、リポジトリの安定性と品質を向上させる。

## 関連issue
#10