### PR TITLE
create_prompt_and_get_response関数の実装

### DIFF
--- a/zoltraak/converter.py
+++ b/zoltraak/converter.py
@@ -191,6 +191,27 @@ def apply_diff_to_target_file(target_file_path, target_diff, client, model="clau
         file.write(modified_content)
 
     print(f"{target_file_path}に修正を適用しました。")
+def create_prompt_and_get_response(client, model, prompt, max_tokens, temperature):
+    """
+    Anthropic APIを使用して、指定されたモデルでプロンプトに基づいてテキストを生成する関数
+
+    Args:
+        client (anthropic.Anthropic): Anthropic APIクライアント
+        model (str): 使用するモデルの名前
+        prompt (str): 送信するプロンプト
+        max_tokens (int): 生成する最大トークン数
+        temperature (float): 生成の多様性を制御する温度パラメータ
+    Returns:
+        str: 生成されたテキスト
+    """
+    response = client.messages.create(
+        model=model,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        system="",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.content[0].text.strip()
 def propose_target_diff(target_file_path, source_diff_text, client):
     """
     ターゲットファイルの変更差分を提案する関数


### PR DESCRIPTION
# 変更点
`zoltraak/converter.py`の`create_prompt_and_get_response`関数が未実装だったため、実装しました。

# 目的
```
$ zoltraak test.md -p "もっと簡潔にして"
差分をどのように適用しますか？
1. AIで適用する
2. 自分で行う
3. 何もせず閉じる
*********************略
modified_content = create_prompt_and_get_response(client, model, prompt, 2000, 0.3)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
NameError: name 'create_prompt_and_get_response' is not defined
```
定義書生成プログラムを書き換える際に上記の選択肢で「1. AIで適用する」を適用した際に`create_prompt_and_get_response`関数が未実装のためエラーが出ていました。