### PR TITLE
-lが未入力のとき再帰で「-l None」が渡される問題を解消

### DIFF
--- a/zoltraak/cli.py
+++ b/zoltraak/cli.py
@@ -166,11 +166,11 @@ def process_text_input(args):
     # print(f"新しい要件定義書 '{md_file_path}' が生成されました。")
     prompt = f"{text}"
 
+    language_option = '-l ' + args.language if args.language is not None else ''
     if args.custom_compiler:
-        os.system(f"zoltraak {md_file_path} -p \"{prompt}\" -cc {args.custom_compiler} -f {args.formatter} -l {args.language}")
+        os.system(f"zoltraak {md_file_path} -p \"{prompt}\" -cc {args.custom_compiler} -f {args.formatter} {language_option}")
     else:
-        os.system(f"zoltraak {md_file_path} -p \"{prompt}\" -c {args.compiler} -f {args.formatter} -l {args.language}")
-
+        os.system(f"zoltraak {md_file_path} -p \"{prompt}\" -c {args.compiler} -f {args.formatter} {language_option}")
 def generate_md_file_name(prompt):
     # promptからファイル名を生成するためにgenerate_response関数を利用
 


### PR DESCRIPTION
https://github.com/dai-motoki/zoltraak/pull/27 で導入された -l オプションをユーザーが指定していない場合、
処理の中で zoltraak を実行する際に「-l None」と渡してしまい、
その結果プロンプトに
```
# Format
- You must generate your response using None.
- Your None should be simple, clear, concise, and logically well structured.
- Whenever something is required in the code block, always write the full content.
```
と加えられている問題がありました。

生成されるmdファイルの冒頭に「None」とついていたり、「None」という1行だけのmdファイルが生成されてしまうケースもあったので、修正を試みました。